### PR TITLE
Add origin timezone column to dataset

### DIFF
--- a/entities/src/main/java/org/n52/series/db/beans/DatasetEntity.java
+++ b/entities/src/main/java/org/n52/series/db/beans/DatasetEntity.java
@@ -98,6 +98,8 @@ public abstract class DatasetEntity extends DescribableEntity
 
     private boolean insitu = true;
 
+    private String originTimezone;
+
     private final Set<RelatedDatasetEntity> relatedDatasets = new LinkedHashSet<>();
 
     public DatasetEntity() {
@@ -395,6 +397,16 @@ public abstract class DatasetEntity extends DescribableEntity
     @Override
     public void setInsitu(boolean insitu) {
         this.insitu = insitu;
+    }
+
+    @Override
+    public String getOriginTimezone() {
+        return originTimezone;
+    }
+
+    @Override
+    public void setOriginTimezone(String originTimezone) {
+        this.originTimezone = originTimezone;
     }
 
     @Override

--- a/entities/src/main/java/org/n52/series/db/beans/dataset/Dataset.java
+++ b/entities/src/main/java/org/n52/series/db/beans/dataset/Dataset.java
@@ -156,6 +156,14 @@ public interface Dataset extends Describable {
 
     void setInsitu(boolean insitu);
 
+    String getOriginTimezone();
+
+    void setOriginTimezone(String originTimezone);
+
+    default boolean isSetOriginTimezone() {
+        return getOriginTimezone() != null && !getOriginTimezone().isEmpty();
+    }
+
     Set<RelatedDatasetEntity> getRelatedDatasets();
 
     void setRelatedObservations(Set<RelatedDatasetEntity> relatedDatasets);

--- a/mappings/src/main/hbm/dataset/DatasetResource.hbm.xml
+++ b/mappings/src/main/hbm/dataset/DatasetResource.hbm.xml
@@ -95,16 +95,22 @@
                 <comment>Flag that indicates if this dataset should be published</comment>
             </column>
         </property>
-        
+
         <property name="mobile" type="org.n52.hibernate.type.SmallBooleanType">
             <column name="is_mobile" not-null="false" default="0" check="is_mobile in (1,0)">
                 <comment>Flag that indicates if the procedure is mobile (1/true) or stationary (0/false).</comment>
             </column>
         </property>
-        
+
         <property name="insitu" type="org.n52.hibernate.type.SmallBooleanType">
             <column name="is_insitu" not-null="false" default="1" check="is_insitu in (1,0)">
                 <comment>Flag that indicates if the procedure is insitu (1/true) or remote (0/false).</comment>
+            </column>
+        </property>
+
+        <property name="originTimezone" type="string" precision="40">
+            <column name="origin_timezome" not-null="false" precision="40">
+                <comment>Define the origin timezone of the dataset timestamps. Possible values are offset (+02:00), id (CET) or full name (Europe/Berlin)</comment>
             </column>
         </property>
 

--- a/mappings/src/main/hbm/ereporting/EReportingDatasetResource.hbm.xml
+++ b/mappings/src/main/hbm/ereporting/EReportingDatasetResource.hbm.xml
@@ -49,13 +49,13 @@
         <property name="published" type="org.n52.hibernate.type.SmallBooleanType">
             <column name="is_published" not-null="true" default="1" check="is_published in (1,0)"/>
         </property>
-        
+
         <property name="mobile" type="org.n52.hibernate.type.SmallBooleanType">
             <column name="is_mobile" not-null="false" default="0" check="is_mobile in (1,0)">
                 <comment>Flag that indicates if the procedure is mobile (1/true) or stationary (0/false).</comment>
             </column>
         </property>
-        
+
         <property name="insitu" type="org.n52.hibernate.type.SmallBooleanType">
             <column name="is_insitu" not-null="false" default="1" check="is_insitu in (1,0)">
                 <comment>Flag that indicates if the procedure is insitu (1/true) or remote (0/false).</comment>
@@ -64,6 +64,12 @@
 
         <property name="hidden" type="org.n52.hibernate.type.SmallBooleanType">
             <column name="is_hidden" not-null="true" default="0" check="is_hidden in (1,0)">
+            </column>
+        </property>
+
+        <property name="originTimezone" type="string" precision="40">
+            <column name="origin_timezome" not-null="false" precision="40">
+                <comment>Define the origin timezone of the dataset timestamps. Possible values are offset (+02:00), id (CET) or full name (Europe/Berlin)</comment>
             </column>
         </property>
 


### PR DESCRIPTION
The origin timezone defines the timezone of the data provided by the dataset. Supported values are
- offset, e.g. +02:00
- id, e.g CET
- name, e.g. Europe/Berlin