### PR TITLE
Fix typo in column name of origin timezone

### DIFF
--- a/mappings/src/main/hbm/dataset/DatasetResource.hbm.xml
+++ b/mappings/src/main/hbm/dataset/DatasetResource.hbm.xml
@@ -109,7 +109,7 @@
         </property>
 
         <property name="originTimezone" type="string" precision="40">
-            <column name="origin_timezome" not-null="false" precision="40">
+            <column name="origin_timezone" not-null="false" precision="40">
                 <comment>Define the origin timezone of the dataset timestamps. Possible values are offset (+02:00), id (CET) or full name (Europe/Berlin)</comment>
             </column>
         </property>

--- a/mappings/src/main/hbm/ereporting/EReportingDatasetResource.hbm.xml
+++ b/mappings/src/main/hbm/ereporting/EReportingDatasetResource.hbm.xml
@@ -68,7 +68,7 @@
         </property>
 
         <property name="originTimezone" type="string" precision="40">
-            <column name="origin_timezome" not-null="false" precision="40">
+            <column name="origin_timezone" not-null="false" precision="40">
                 <comment>Define the origin timezone of the dataset timestamps. Possible values are offset (+02:00), id (CET) or full name (Europe/Berlin)</comment>
             </column>
         </property>


### PR DESCRIPTION
The name of the origin timezone column was origin_timezome which is fixed with this.